### PR TITLE
update pythia to run with min q2

### DIFF
--- a/pythiaGeneration/defaultPythiaeRhicSettings.txt
+++ b/pythiaGeneration/defaultPythiaeRhicSettings.txt
@@ -1,6 +1,6 @@
 F2PY,1998         ! F2-Model, R-Parametrisation
 0                 ! switch for rad corrections; 0:no, 1:yes, 2:gen.lookup table, requires radgen/ subdir
-0                 ! Pythia-Model = 0 standard GVMD generation in Pythia-x and Q2; = 1 GVMD model with generation in y and Q2 as for radgen  DEFAULT is 1!
+1                 ! Pythia-Model = 0 standard GVMD generation in Pythia-x and Q2; = 1 GVMD model with generation in y and Q2 as for radgen  DEFAULT is 1!
 1,1               ! A-Tar and Z-Tar
 1,1               ! nuclear pdf parameter1: nucleon mass number A, charge number Z
 201               ! nuclear pdf parameter2: correction order x*100+y x= 1:LO, 2:NLO y:error set

--- a/pythiaGeneration/runPythiaeRhic.py
+++ b/pythiaGeneration/runPythiaeRhic.py
@@ -13,7 +13,7 @@
 import os
 import sys
 
-def runPythia(outfile, protonEnergy, electronEnergy, nEvents, basePath):
+def runPythia(outfile, protonEnergy, electronEnergy, minQ2, nEvents, basePath):
     """
     This function takes several arguments and runs the pythia truth generation
     with the parameters given as arguments and the "default file", which 
@@ -43,8 +43,8 @@ def runPythia(outfile, protonEnergy, electronEnergy, nEvents, basePath):
     
     # add the x, q, and y, which we might want to add as arguments later
     finalPythiaFile.write("1e-09, 0.99       ! xmin and xmax\n")
-    finalPythiaFile.write("1e-02,1.00        ! ymin and ymax\n")
-    finalPythiaFile.write("9,20000         ! Q2min and Q2max\n")
+    finalPythiaFile.write("1e-04,1.00        ! ymin and ymax\n")
+    finalPythiaFile.write(minQ2 +",20000         ! Q2min and Q2max\n")
     
     # add all the other parameters
     finalPythiaFile.write(defaultPythia)

--- a/runSimWorkflow.py
+++ b/runSimWorkflow.py
@@ -27,13 +27,15 @@ smearedfile = sys.argv[1]
 truthfile = sys.argv[2]
 protonEnergy = sys.argv[3]
 electronEnergy = sys.argv[4]
-nEvents = sys.argv[5]
+minQ2 = sys.argv[5]
+nEvents = sys.argv[6]
 
 
 # generate events
 runPythiaeRhic.runPythia(truthfile,
                          protonEnergy,
                          electronEnergy,
+                         minQ2,
                          nEvents,
                          basePath)
 


### PR DESCRIPTION
This PR fixes the pythia file to run with a minimum Q2 so we can actually generate jet events from high Q2 processes.