### PR TITLE
Write output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ dict_*.*
 *.out
 *.log
 *.d
-*_dict_*
+*_dict*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ dict_*.*
 *.err
 *.out
 *.log
+*.d
+*_dict_*

--- a/analysisCode/Makefile
+++ b/analysisCode/Makefile
@@ -33,7 +33,7 @@ CXXFLAGS += $(ROOTCFLAGS) -I$(HEADRDIR) $(LIBS)
 CXXFLAGS += -Wno-unused-variable -Wno-sign-compare
 
 # to add a class just add the corresponding .o library here
-MODULES = src/EventLoop.o src/TruthEvent.o src/SmearedEvent.o
+MODULES = src/TruthEvent.o src/SmearedEvent.o src/EventLoop.o 
 
 
 all: EventLoop

--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -20,10 +20,8 @@ int main(int argc, char **argv)
   
   TFile *outfile = new TFile(outputFile.c_str(), "recreate");
   jetTree = new TTree("jettree", "A tree with jets");
-  jetTree->Branch("truthR1Jets", &truthR1Jets);
-  jetTree->Branch("recoR1Jets", &recoR1Jets);
-  jetTree->Branch("recoR1SDJets", &recoR1SDJets);
-  jetTree->Branch("matchedR1Jets", &matchedR1Jets);
+
+  setupJetTree(jetTree);
 
   TruthEvent event;
   SmearedEvent smearevent;
@@ -107,31 +105,34 @@ std::vector<fastjet::PseudoJet> getTruthJets(fastjet::ClusterSequence *truthcs,
 
   truthcs = new fastjet::ClusterSequence(truthJets, jetdef.getJetDef());
 
-  std::vector<fastjet::PseudoJet> allTruthJets = fastjet::sorted_by_pt(truthcs->inclusive_jets());
+  PseudoJetVec allTruthJets = fastjet::sorted_by_pt(truthcs->inclusive_jets());
   /// Make eta/pt selections
   fastjet::Selector selectPt = fastjet::SelectorPtMin(jetdef.getMinJetPt());
   fastjet::Selector selectEta = fastjet::SelectorAbsRapMax(jetdef.getMaxJetRapidity());
   fastjet::Selector select = selectPt and selectEta;
   
-  std::vector<fastjet::PseudoJet> selectTruthJets = select(allTruthJets);
+  PseudoJetVec selectTruthJets = select(allTruthJets);
   
   return selectTruthJets;
 }
 
 
-void setupTree(TTree *tree)
+void setupJetTree(TTree *tree)
 {
+
+  jetTree->Branch("truthR1Jets", &truthR1Jets);
+  jetTree->Branch("recoR1Jets", &recoR1Jets);
+  jetTree->Branch("recoR1SDJets", &recoR1SDJets);
+  jetTree->Branch("matchedR1Jets", &matchedR1Jets);
 
 
   return;
 }
 
 
-std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>
-   convertToTLorentzVectors(
-       std::vector<fastjet::PseudoJet> pseudoJets)
+JetConstVec convertToTLorentzVectors(PseudoJetVec pseudoJets)
 {
-  std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>> jets;
+  JetConstVec jets;
 
   for(int jet = 0; jet < pseudoJets.size(); jet++)
     {
@@ -145,8 +146,8 @@ std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>
 		      pseudojet.e());
       
       /// Get jet constituents
-      std::vector<fastjet::PseudoJet> constituents = pseudojet.constituents();
-      std::vector<TLorentzVector> tConstituents;
+      PseudoJetVec constituents = pseudojet.constituents();
+      TLorentzVectorVec tConstituents;
       for(int con = 0; con < constituents.size(); con++)
 	{
 	  fastjet::PseudoJet fjConstituent = constituents.at(con);

--- a/analysisCode/src/SmearedEvent.cpp
+++ b/analysisCode/src/SmearedEvent.cpp
@@ -68,7 +68,8 @@ void SmearedEvent::setSmearedParticles()
   return;
 }
 
-std::vector<fastjet::PseudoJet> SmearedEvent::getRecoJets(JetDef jetDef)
+std::vector<fastjet::PseudoJet> SmearedEvent::getRecoJets(fastjet::ClusterSequence *cs, 
+							  JetDef jetDef)
 {
   /// Create the cluster sequence
   cs = new fastjet::ClusterSequence(m_particles, jetDef.getJetDef());
@@ -156,3 +157,5 @@ std::vector<std::vector<fastjet::PseudoJet>> SmearedEvent::matchTruthRecoJets(
   return matchedVector;
 
 }
+
+

--- a/analysisCode/src/SmearedEvent.cpp
+++ b/analysisCode/src/SmearedEvent.cpp
@@ -48,16 +48,17 @@ void SmearedEvent::setSmearedParticles()
       /// Skip the scattered electron, since it is special
       if(particle->GetE() == m_scatLepton->GetE())
 	continue;
-   
-      std::cout << "Truth  : "<<truthParticle->Id() 
-		<< " " <<truthParticle->GetPx() << " " 
-		<< truthParticle->GetPy() << " " << truthParticle->GetPz()
-		<< " " << truthParticle->GetE() << std::endl;
-      
-      std::cout << "Smeared : " << particle->GetPx() << " " 
-		<< particle->GetPy() << " " << particle->GetPz() << " " 
-		<< particle->GetE() << std::endl;
-      
+      if(m_verbosity > 0)
+	{
+	  std::cout << "Truth  : "<<truthParticle->Id() 
+		    << " " <<truthParticle->GetPx() << " " 
+		    << truthParticle->GetPy() << " " << truthParticle->GetPz()
+		    << " " << truthParticle->GetE() << std::endl;
+	  
+	  std::cout << "Smeared : " << particle->GetPx() << " " 
+		    << particle->GetPy() << " " << particle->GetPz() << " " 
+		    << particle->GetE() << std::endl;
+	}
 
       m_particles.push_back(fastjet::PseudoJet(particle->GetPx(),
 					       particle->GetPy(),
@@ -68,13 +69,13 @@ void SmearedEvent::setSmearedParticles()
   return;
 }
 
-std::vector<fastjet::PseudoJet> SmearedEvent::getRecoJets(fastjet::ClusterSequence *cs, 
-							  JetDef jetDef)
+PseudoJetVec SmearedEvent::getRecoJets(fastjet::ClusterSequence *cs, 
+				       JetDef jetDef)
 {
   /// Create the cluster sequence
   cs = new fastjet::ClusterSequence(m_particles, jetDef.getJetDef());
   
-  std::vector<fastjet::PseudoJet> allRecoJets = fastjet::sorted_by_pt(cs->inclusive_jets());
+  PseudoJetVec allRecoJets = fastjet::sorted_by_pt(cs->inclusive_jets());
 
   if(m_verbosity > 1)
     {
@@ -87,18 +88,18 @@ std::vector<fastjet::PseudoJet> SmearedEvent::getRecoJets(fastjet::ClusterSequen
   fastjet::Selector selectEta = fastjet::SelectorAbsRapMax(jetDef.getMaxJetRapidity());
   fastjet::Selector select = selectPt and selectEta;
   
-  std::vector<fastjet::PseudoJet> selectJets = select(allRecoJets);
+  PseudoJetVec selectJets = select(allRecoJets);
 
   return selectJets;
 
 }
 
-std::vector<fastjet::PseudoJet> SmearedEvent::getRecoSoftDropJets(std::vector<fastjet::PseudoJet> recoJets, SoftDropJetDef sdJetDef)
+PseudoJetVec SmearedEvent::getRecoSoftDropJets(PseudoJetVec recoJets, SoftDropJetDef sdJetDef)
 {
 
   fastjet::contrib::SoftDrop sd(sdJetDef.getSoftDrop());
   
-  std::vector<fastjet::PseudoJet> softDropJets;
+  PseudoJetVec softDropJets;
  
   for(int jet = 0; jet < recoJets.size(); ++jet)
     {
@@ -111,12 +112,12 @@ std::vector<fastjet::PseudoJet> SmearedEvent::getRecoSoftDropJets(std::vector<fa
 }
 
 
-std::vector<std::vector<fastjet::PseudoJet>> SmearedEvent::matchTruthRecoJets(
-	    std::vector<fastjet::PseudoJet> truthjets,
-	    std::vector<fastjet::PseudoJet> recojets)
+std::vector<PseudoJetVec> SmearedEvent::matchTruthRecoJets(
+	    PseudoJetVec truthjets,
+	    PseudoJetVec recojets)
 {
-  std::vector<fastjet::PseudoJet> matchJetPair;
-  std::vector<std::vector<fastjet::PseudoJet>> matchedVector;
+  PseudoJetVec matchJetPair;
+  std::vector<PseudoJetVec> matchedVector;
   
 
   for(int reco = 0; reco < recojets.size(); ++reco)

--- a/analysisCode/src/fastJetLinker.C
+++ b/analysisCode/src/fastJetLinker.C
@@ -1,0 +1,8 @@
+#include <TLorentzVector.h>
+#include <vector>
+#include <utility>
+#include <tuple>
+#ifdef __MAKECINT__
+#pragma link C++ class std::vector<TLorentzVector>+;
+#pragma link C++ class std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>+;
+#endif

--- a/analysisCode/src/include/EventLoop.h
+++ b/analysisCode/src/include/EventLoop.h
@@ -1,0 +1,45 @@
+/// Fastjet includes
+#include <fastjet/ClusterSequence.hh>
+#include <fastjet/Selector.hh>
+#include <fastjet/contrib/SoftDrop.hh>
+#include <fastjet/PseudoJet.hh>
+
+/// Root includes
+#include <TFile.h>
+#include <TTree.h>
+#include <TSystem.h>
+#include <TRint.h>
+#include <TROOT.h>
+
+/// EIC smear includes
+#include <eicsmear/erhic/EventPythia.h>
+#include <eicsmear/smear/EventS.h>
+
+/// Local includes
+#include "TruthEvent.h"
+#include "SmearedEvent.h"
+#include "JetDef.h"
+#include "SoftDropJetDef.h"
+
+#include <iostream>
+#include <vector>
+
+using PseudoJetVec = std::vector<fastjet::PseudoJet>;
+
+PseudoJetVec getTruthJets(fastjet::ClusterSequence *truthcs, 
+			  erhic::EventPythia *truthEvent, 
+			  JetDef jetdef);
+
+void setupTree(TTree *tree);
+
+std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>
+  convertToTLorentzVectors(std::vector<fastjet::PseudoJet> pseudoJets);
+
+std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>> 
+  truthR1Jets, recoR1Jets, recoR1SDJets;
+
+std::vector<PseudoJetVec> matchedR1Jets;
+
+fastjet::ClusterSequence *cs, *truthcs;
+
+TTree *jetTree;

--- a/analysisCode/src/include/EventLoop.h
+++ b/analysisCode/src/include/EventLoop.h
@@ -25,18 +25,19 @@
 #include <vector>
 
 using PseudoJetVec = std::vector<fastjet::PseudoJet>;
+using TLorentzVectorVec = std::vector<TLorentzVector>;
+using JetConstPair = std::pair<TLorentzVector, std::vector<TLorentzVector>>;
+using JetConstVec = std::vector<JetConstPair>;
 
 PseudoJetVec getTruthJets(fastjet::ClusterSequence *truthcs, 
 			  erhic::EventPythia *truthEvent, 
 			  JetDef jetdef);
 
-void setupTree(TTree *tree);
+void setupJetTree(TTree *tree);
 
-std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>
-  convertToTLorentzVectors(std::vector<fastjet::PseudoJet> pseudoJets);
+JetConstVec convertToTLorentzVectors(PseudoJetVec pseudoJets);
 
-std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>> 
-  truthR1Jets, recoR1Jets, recoR1SDJets;
+JetConstVec truthR1Jets, recoR1Jets, recoR1SDJets;
 
 std::vector<PseudoJetVec> matchedR1Jets;
 

--- a/analysisCode/src/include/SmearedEvent.h
+++ b/analysisCode/src/include/SmearedEvent.h
@@ -12,7 +12,10 @@
 #include "JetDef.h"
 #include "SoftDropJetDef.h"
 
-
+using PseudoJetVec = std::vector<fastjet::PseudoJet>;
+using TLorentzVectorVec = std::vector<TLorentzVector>;
+using JetConstPair = std::pair<TLorentzVector, std::vector<TLorentzVector>>;
+using JetConstVec = std::vector<JetConstPair>;
 
 class SmearedEvent {
   
@@ -29,15 +32,13 @@ class SmearedEvent {
   void processEvent();
   void setVerbosity(int verb) { m_verbosity = verb; }
 
-  std::vector<fastjet::PseudoJet> getRecoJets(fastjet::ClusterSequence *cs,
-					      JetDef jetDef);
-  std::vector<fastjet::PseudoJet> getRecoSoftDropJets(
-         std::vector<fastjet::PseudoJet> recoJets, 
-	 SoftDropJetDef sdJetDef);
+  PseudoJetVec getRecoJets(fastjet::ClusterSequence *cs,
+			   JetDef jetDef);
+  PseudoJetVec getRecoSoftDropJets(PseudoJetVec recoJets, 
+				   SoftDropJetDef sdJetDef);
 
-  std::vector<std::vector<fastjet::PseudoJet>> matchTruthRecoJets(
-         std::vector<fastjet::PseudoJet> truthjets, 
-	 std::vector<fastjet::PseudoJet> recojets);
+  std::vector<PseudoJetVec> matchTruthRecoJets(PseudoJetVec truthjets, 
+					       PseudoJetVec recojets);
 
 
  private:
@@ -47,16 +48,13 @@ class SmearedEvent {
 
   const Smear::ParticleMCS *m_scatLepton;
 
-  std::vector<std::vector<fastjet::PseudoJet>> m_matchedJets;
-  std::vector<fastjet::PseudoJet> m_particles;
+  std::vector<PseudoJetVec> m_matchedJets;
+  PseudoJetVec m_particles;
 
   int m_verbosity = 0;
 
   void setScatteredLepton();
   void setSmearedParticles();
-
-  std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>
-    convertPseudoJetsToTLorentzVectors(std::vector<fastjet::PseudoJet> pseudoJets);
   
 
 };

--- a/analysisCode/src/include/SmearedEvent.h
+++ b/analysisCode/src/include/SmearedEvent.h
@@ -1,6 +1,9 @@
 #ifndef SMEAREDEVENT_H
 #define SMEAREDEVENT_H
 
+#include <utility>
+#include <tuple>
+
 #include <eicsmear/smear/EventS.h>
 #include <eicsmear/erhic/EventPythia.h>
 
@@ -8,6 +11,8 @@
 
 #include "JetDef.h"
 #include "SoftDropJetDef.h"
+
+
 
 class SmearedEvent {
   
@@ -24,10 +29,16 @@ class SmearedEvent {
   void processEvent();
   void setVerbosity(int verb) { m_verbosity = verb; }
 
-  std::vector<fastjet::PseudoJet> getRecoJets(JetDef jetDef);
-  std::vector<fastjet::PseudoJet> getRecoSoftDropJets(std::vector<fastjet::PseudoJet> recoJets, SoftDropJetDef sdJetDef);
+  std::vector<fastjet::PseudoJet> getRecoJets(fastjet::ClusterSequence *cs,
+					      JetDef jetDef);
+  std::vector<fastjet::PseudoJet> getRecoSoftDropJets(
+         std::vector<fastjet::PseudoJet> recoJets, 
+	 SoftDropJetDef sdJetDef);
 
-  std::vector<std::vector<fastjet::PseudoJet>> matchTruthRecoJets(std::vector<fastjet::PseudoJet> truthjets, std::vector<fastjet::PseudoJet> recojets);
+  std::vector<std::vector<fastjet::PseudoJet>> matchTruthRecoJets(
+         std::vector<fastjet::PseudoJet> truthjets, 
+	 std::vector<fastjet::PseudoJet> recojets);
+
 
  private:
   /// Need truth event for identifying only final state particles
@@ -39,12 +50,13 @@ class SmearedEvent {
   std::vector<std::vector<fastjet::PseudoJet>> m_matchedJets;
   std::vector<fastjet::PseudoJet> m_particles;
 
-  fastjet::ClusterSequence *cs;
-
   int m_verbosity = 0;
 
   void setScatteredLepton();
   void setSmearedParticles();
+
+  std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>
+    convertPseudoJetsToTLorentzVectors(std::vector<fastjet::PseudoJet> pseudoJets);
   
 
 };


### PR DESCRIPTION
This PR introduces some code to be able to write jets and constituents to an output root tree. 

Unfortunately we can only write TLorentzVector objects to trees, rather than fastjet::PseudoJet objects. The reason is that the PseudoJet information is contained within a fastjet::ClusterSequence, which changes on an event-by-event basis. So, a function to convert the information from PseudoJets to TLorentzVectors was added. 

Trees are written out in the form of `std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>`, where the first key in the pair is the jet 4 vector and the second key in the pair is a vector of jet constituents.