### PR TITLE
Smeared particle cuts

### DIFF
--- a/analysisCode/src/BreitFrame.cpp
+++ b/analysisCode/src/BreitFrame.cpp
@@ -8,7 +8,7 @@ void BreitFrame::labToBreitTruth( TLorentzVector *l )
   double E_breit =  2*m_truthEvent->GetTrueX()*P_lab.E() + q_lab.E();
   TVector3 beta(  2*m_truthEvent->GetTrueX()*P_lab.Vect() + q_lab.Vect() );
   beta *= 1/E_breit;
-  TVector3 z_axis(0,0,1);
+  TVector3 z_axis(0,0,-1);
   l->Boost(-beta);
   q_lab.Boost(-beta);
   // Double check signage or if inverse rotation is needed... 
@@ -28,7 +28,7 @@ void BreitFrame::labToBreitSmear( TLorentzVector *l )
   double E_breit =  2*m_smearEvent->GetX()*P.E() + q.E();
   TVector3 beta(  2*m_smearEvent->GetX()*P.Vect() + q.Vect() );
   beta *= 1/E_breit;
-  TVector3 z_axis(0,0,1);
+  TVector3 z_axis(0,0,-1);
   l->Boost(-beta);
   q.Boost(-beta);
   // Double check signage or if inverse rotation is needed... 

--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -15,6 +15,8 @@ int main(int argc, char **argv)
   /// Name of output root file for trees to reside
   std::string outputFile = argv[3];
 
+  int breitFrame = std::stoi(argv[4]);
+
   TFile mc(mcFile.c_str());
   TTree *mctree = (TTree*)mc.Get("EICTree");
   
@@ -45,6 +47,7 @@ int main(int argc, char **argv)
 
       TruthEvent trueEvent(*truthEvent);
       trueEvent.setVerbosity(0);
+      trueEvent.useBreitFrame(breitFrame);
       /// Set event level cuts
       trueEvent.setMinQ2(16);
       trueEvent.setMinY(0.01);
@@ -65,7 +68,8 @@ int main(int argc, char **argv)
 	}
 
       SmearedEvent smearedEvent(*truthEvent, *smearEvent);
-      smearedEvent.setVerbosity(0);
+      smearedEvent.setVerbosity(0);     
+      smearedEvent.useBreitFrame(breitFrame);
       smearedEvent.processEvent();
 
       PseudoJetVec fjrecoR1Jets = smearedEvent.getRecoJets(cs, R1jetdef);

--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -45,17 +45,24 @@ int main(int argc, char **argv)
 
       mctree->GetEntry(event);
 
+      truex = truthEvent->GetTrueX();
+      truey = truthEvent->GetTrueY();
+      trueq2 = truthEvent->GetTrueQ2();
+     
       TruthEvent trueEvent(*truthEvent);
       trueEvent.setVerbosity(0);
       trueEvent.useBreitFrame(breitFrame);
+      exchangeBoson = trueEvent.getExchangeBoson();
+
       /// Set event level cuts
       trueEvent.setMinQ2(16);
       trueEvent.setMinY(0.01);
       trueEvent.setMaxY(0.95);
       trueEvent.setMinX(0.00001);
       /// Check the cuts
-      if(!trueEvent.passCuts())
+      if(!trueEvent.passCuts()){
 	continue;
+      }
 
       trueEvent.processEvent();
 
@@ -63,7 +70,6 @@ int main(int argc, char **argv)
       PseudoJetVec fjtruthR1SDJets = trueEvent.getTruthSoftDropJets(fjtruthR1Jets, R1sd);
       if(fjtruthR1Jets.size() == 0)
 	{
-	  std::cout<<"no truth jets"<<std::endl;
 	  continue;
 	}
 
@@ -111,7 +117,10 @@ void setupJetTree(TTree *tree)
   jetTree->Branch("recoR1Jets", &recoR1Jets);
   jetTree->Branch("recoR1SDJets", &recoR1SDJets);
   jetTree->Branch("matchedR1Jets", &matchedR1Jets);
-
+  jetTree->Branch("exchangeBoson", &exchangeBoson);
+  jetTree->Branch("truex",&truex,"truex/D");
+  jetTree->Branch("truey",&truey,"truey/D");
+  jetTree->Branch("trueq2",&trueq2,"trueq2/D");
 
   return;
 }

--- a/analysisCode/src/SmearedEvent.cpp
+++ b/analysisCode/src/SmearedEvent.cpp
@@ -91,7 +91,6 @@ void SmearedEvent::setSmearedParticles()
 	    ///else assume a charged pion
 	    e = std::sqrt(p * p + 0.139 * 0.139);
 	  }
-				 
 	}
       
       /// Cal cluster only, no momentum info
@@ -101,11 +100,11 @@ void SmearedEvent::setSmearedParticles()
 	  auto abspid = std::abs(truthParticle->GetPdgCode());
 	  bool EM = abspid == 22 || abspid == 11;
 	  if(EM){
-	    /// assume m =0 since electron mass is so small
+	    /// assume m = 0 since electron mass is so small
 	    p = e;	    
 	  } else {
-	    //// assume pion mass
-	    p = std::sqrt(e * e - 0.139 * 0.139);
+	    //// assume neutron mass
+	    p = std::sqrt(e * e -0.939 * 0.939);
 	  }
 
 	  auto phi = particle->GetPhi();
@@ -113,6 +112,13 @@ void SmearedEvent::setSmearedParticles()
 	  px = p * sin(theta) * cos(phi);
 	  py = p * sin(theta) * sin(phi);
 	  pz = p * cos(theta);
+
+	}
+
+      if(m_verbosity > 3)
+	{
+	  std::cout<<"particle to be smeared "<<std::endl;
+	  std::cout<<"("<<px<<","<<py<<","<<pz<<","<<e<<")"<<std::endl;
 	}
 
       TLorentzVector *partFourVec = new TLorentzVector();

--- a/analysisCode/src/TruthEvent.cpp
+++ b/analysisCode/src/TruthEvent.cpp
@@ -15,6 +15,20 @@ void TruthEvent::processEvent()
 
 }
 
+TLorentzVector TruthEvent::getExchangeBoson()
+{
+  TLorentzVector *vector = new TLorentzVector( m_truthEvent->ExchangeBoson()->Get4Vector());
+  
+  if(m_breitFrame){
+    
+    BreitFrame breit(*m_truthEvent);
+    breit.labToBreitTruth( vector );
+    
+  }
+    
+  return *vector;
+
+}
 bool TruthEvent::passCuts()
 {
   double y = m_truthEvent->GetTrueY();

--- a/analysisCode/src/TruthEvent.cpp
+++ b/analysisCode/src/TruthEvent.cpp
@@ -60,6 +60,10 @@ void TruthEvent::setTruthParticles()
       if(truthParticle->GetE() == m_scatLepton->GetE())
 	continue;
 
+      /// Check that eta is within nominal detector acceptance
+      if(fabs(truthParticle->GetEta()) > 3.5)
+	continue;
+
       if(m_verbosity > 2)
 	{
 	  std::cout << "Truth (lab) : " <<truthParticle->Id() 
@@ -70,7 +74,8 @@ void TruthEvent::setTruthParticles()
 
       // Transform Particle 4 Vectors to the Breit Frame 
       TLorentzVector *partFourVec = new TLorentzVector( truthParticle->PxPyPzE() );
-      breit.labToBreitTruth( partFourVec );
+      if(m_breitFrame)
+	breit.labToBreitTruth( partFourVec );
       
       if(m_verbosity > 0)
 	{

--- a/analysisCode/src/include/EventLoop.h
+++ b/analysisCode/src/include/EventLoop.h
@@ -38,7 +38,8 @@ void setupJetTree(TTree *tree);
 JetConstVec convertToTLorentzVectors(PseudoJetVec pseudoJets);
 
 JetConstVec truthR1Jets, recoR1Jets, recoR1SDJets;
-
+double truex, truey, trueq2;
+TLorentzVector exchangeBoson;
 std::vector<std::vector<JetConstPair>> matchedR1Jets;
 
 fastjet::ClusterSequence *cs, *truthcs;

--- a/analysisCode/src/include/SmearedEvent.h
+++ b/analysisCode/src/include/SmearedEvent.h
@@ -41,14 +41,14 @@ class SmearedEvent {
   std::vector<PseudoJetVec> matchTruthRecoJets(PseudoJetVec truthjets, 
 					       PseudoJetVec recojets);
 
-
+  void useBreitFrame(bool yesorno) { m_breitFrame = yesorno; }
  private:
   /// Need truth event for identifying only final state particles
   erhic::EventPythia *m_truthEvent;
   Smear::Event *m_smearEvent;
 
   const Smear::ParticleMCS *m_scatLepton;
-
+  bool m_breitFrame;
   std::vector<PseudoJetVec> m_matchedJets;
   PseudoJetVec m_particles;
 

--- a/analysisCode/src/include/TruthEvent.h
+++ b/analysisCode/src/include/TruthEvent.h
@@ -43,6 +43,7 @@ class TruthEvent {
   void setMaxY(double y) {m_maxY = y; }
   void setMinX(double x) {m_minX = x; }
   bool passCuts();
+  TLorentzVector getExchangeBoson();
 
  private:
 

--- a/analysisCode/src/include/TruthEvent.h
+++ b/analysisCode/src/include/TruthEvent.h
@@ -37,7 +37,7 @@ class TruthEvent {
   PseudoJetVec getTruthSoftDropJets(PseudoJetVec recoJets, 
 				   SoftDropJetDef sdJetDef);
 
-
+  void useBreitFrame(bool yesorno) { m_breitFrame = yesorno; }
   void setMinQ2(double q2) { m_minq2 = q2; }
   void setMinY(double y) {m_minY = y; }
   void setMaxY(double y) {m_maxY = y; }
@@ -50,6 +50,7 @@ class TruthEvent {
   double m_minY;
   double m_maxY;
   double m_minX;
+  bool m_breitFrame;
 
   erhic::EventPythia *m_truthEvent;
 


### PR DESCRIPTION
This PR introduces some logic to handle EICSmear edge cases regarding neutral vs. charged particles.

There are also fixes for the breit frame transformation, where the rotation is now performed to the negative z axis. 

You can now run the analysis code for either lab frame or breit frame by providing an argument. 