### PR TITLE
Edge cases

### DIFF
--- a/analysisCode/src/BreitFrame.cpp
+++ b/analysisCode/src/BreitFrame.cpp
@@ -24,13 +24,12 @@ void BreitFrame::labToBreitSmear( TLorentzVector *l )
   TLorentzVector q = lo - lprime;
 
   TLorentzVector P = m_smearEvent->BeamHadron()->PxPyPzE();
-
   double E_breit =  2*m_smearEvent->GetX()*P.E() + q.E();
   TVector3 beta(  2*m_smearEvent->GetX()*P.Vect() + q.Vect() );
   beta *= 1/E_breit;
   TVector3 z_axis(0,0,-1);
   l->Boost(-beta);
-  q.Boost(-beta);
+ 
   // Double check signage or if inverse rotation is needed... 
   l->Rotate(q.Vect().Angle(z_axis), q.Vect().Cross(z_axis).Unit());
 

--- a/analysisCode/src/BreitFrame.cpp
+++ b/analysisCode/src/BreitFrame.cpp
@@ -29,7 +29,7 @@ void BreitFrame::labToBreitSmear( TLorentzVector *l )
   beta *= 1/E_breit;
   TVector3 z_axis(0,0,-1);
   l->Boost(-beta);
- 
+  q.Boost(-beta);
   // Double check signage or if inverse rotation is needed... 
   l->Rotate(q.Vect().Angle(z_axis), q.Vect().Cross(z_axis).Unit());
 


### PR DESCRIPTION
This PR removes seg faults that come about from some edge cases of EIC smear where 
1. There is a neutral hadron with low energy that gets smeared out to have less energy than its corresponding invariant mass
2. There is a case where the boost into the Breit frame introduces null vectors due to the smeared q vector being incorrect.