### PR TITLE
Particle Correlations

### DIFF
--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -82,7 +82,8 @@ int main(int argc, char **argv)
       recy = smearEvent->GetY();
       recq2 = smearEvent->GetQ2();
       smearExchangeBoson = smearedEvent.getExchangeBoson();
-      
+      matchedParticles = smearedEvent.getMatchedParticles();      
+
       PseudoJetVec fjrecoR1Jets = smearedEvent.getRecoJets(cs, R1jetdef);
       std::vector<PseudoJetVec> fjmatchedR1Jets = 
       	smearedEvent.matchTruthRecoJets(fjtruthR1Jets, fjrecoR1Jets);
@@ -114,11 +115,12 @@ int main(int argc, char **argv)
 std::vector<std::vector<JetConstPair>> convertMatchedJetVec(std::vector<PseudoJetVec> vec)
 {
   std::vector<std::vector<JetConstPair>> matchedJets;
+  //num jets per event
   for(int i = 0; i < vec.size(); i++)
     {
       PseudoJetVec pair = vec.at(i);
       JetConstVec TLpair = convertToTLorentzVectors(pair);
-
+      
       matchedJets.push_back(TLpair);
     }
 
@@ -141,7 +143,7 @@ void setupJetTree(TTree *tree)
   jetTree->Branch("recx",&recx,"recx/D");
   jetTree->Branch("recy",&recy,"recy/D");
   jetTree->Branch("recq2",&recq2,"recq2/D");
-
+  jetTree->Branch("matchedParticles",&matchedParticles);
   return;
 }
 

--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -78,9 +78,10 @@ int main(int argc, char **argv)
       smearedEvent.setVerbosity(0);     
       smearedEvent.useBreitFrame(breitFrame);
       smearedEvent.processEvent();
-      recx = smearedEvent.getSmearedX();
-      recy = smearedEvent.getSmearedY();
-      recq2 = smearedEvent.getSmearedQ2();
+      recx = smearEvent->GetX();
+      recy = smearEvent->GetY();
+      recq2 = smearEvent->GetQ2();
+      smearExchangeBoson = smearedEvent.getExchangeBoson();
       
       PseudoJetVec fjrecoR1Jets = smearedEvent.getRecoJets(cs, R1jetdef);
       std::vector<PseudoJetVec> fjmatchedR1Jets = 
@@ -133,6 +134,7 @@ void setupJetTree(TTree *tree)
   jetTree->Branch("matchedR1Jets", &matchedR1Jets);
   jetTree->Branch("matchedR1SDJets", &matchedR1SDJets);
   jetTree->Branch("exchangeBoson", &exchangeBoson);
+  jetTree->Branch("smearExchangeBoson", &smearExchangeBoson);
   jetTree->Branch("truex",&truex,"truex/D");
   jetTree->Branch("truey",&truey,"truey/D");
   jetTree->Branch("trueq2",&trueq2,"trueq2/D");

--- a/analysisCode/src/SmearedEvent.cpp
+++ b/analysisCode/src/SmearedEvent.cpp
@@ -22,33 +22,19 @@ void SmearedEvent::setScatteredLepton()
 	       << m_scatLepton->GetPy() << " " << m_scatLepton->GetPz()
 	       << " " << m_scatLepton->GetE() << std::endl;
     }
-  
-  /// calculate q2, x, y
-  TLorentzVector scat, init, q, p;
-  p.SetPxPyPzE(m_truthEvent->BeamHadron()->GetPx(),
-	       m_truthEvent->BeamHadron()->GetPy(),
-	       m_truthEvent->BeamHadron()->GetPz(),
-	       m_truthEvent->BeamHadron()->GetE());
-  
-  scat.SetPxPyPzE(m_scatLepton->GetPx(),
-		  m_scatLepton->GetPy(),
-		  m_scatLepton->GetPz(),
-		  m_scatLepton->GetE());
-  
-  init.SetPxPyPzE(m_truthEvent->BeamLepton()->GetPx(),
-		  m_truthEvent->BeamLepton()->GetPy(),
-		  m_truthEvent->BeamLepton()->GetPz(),
-		  m_truthEvent->BeamLepton()->GetE());
-
-  q = init - scat;
-
-  m_q2 = -1 * q.Mag2();
-  m_nu = init.E() - scat.E();
-  m_x = m_q2 / (2. * p.Dot(q));
-  m_y = (q.Dot(p)) / (init.Dot(p));
-
 }
 
+TLorentzVector SmearedEvent::getExchangeBoson()
+{
+  TLorentzVector *vector = new TLorentzVector( m_smearEvent->ExchangeBoson()->Get4Vector());
+  if(m_breitFrame)
+    {
+      BreitFrame breit(*m_truthEvent, *m_smearEvent);
+      breit.labToBreitSmear(vector);
+    }
+  return *vector;
+
+}
 void SmearedEvent::setSmearedParticles()
 {
   double epsilon = 1e-7;

--- a/analysisCode/src/fastJetLinker.C
+++ b/analysisCode/src/fastJetLinker.C
@@ -6,4 +6,5 @@
 #pragma link C++ class std::vector<TLorentzVector>+;
 #pragma link C++ class std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>+;
 #pragma link C++ class std::vector<std::vector<std::pair<TLorentzVector, std::vector<TLorentzVector>>>>+;
+#pragma link C++ class std::vector<std::pair<TLorentzVector,TLorentzVector>>+;
 #endif

--- a/analysisCode/src/include/EventLoop.h
+++ b/analysisCode/src/include/EventLoop.h
@@ -42,7 +42,7 @@ std::vector<std::vector<JetConstPair>> convertMatchedJetVec(std::vector<PseudoJe
 JetConstVec truthR1Jets, recoR1Jets, recoR1SDJets;
 double truex, truey, trueq2;
 double recx, recy, recq2;
-TLorentzVector exchangeBoson;
+TLorentzVector exchangeBoson, smearExchangeBoson;
 
 /// This structure is a vector of vector of matched truth-reco jets. 
 /// Each entry of std::vector<JetConstPair> is length 2 - first the truth

--- a/analysisCode/src/include/EventLoop.h
+++ b/analysisCode/src/include/EventLoop.h
@@ -26,6 +26,8 @@
 
 using PseudoJetVec = std::vector<fastjet::PseudoJet>;
 using TLorentzVectorVec = std::vector<TLorentzVector>;
+using TLorentzPair = std::pair<TLorentzVector, TLorentzVector>;
+using TLorentzPairVec = std::vector<TLorentzPair>;
 /// A JetConstPair is a pair of a jet 4 vector and vector of jet constituents
 using JetConstPair = std::pair<TLorentzVector, std::vector<TLorentzVector>>;
 using JetConstVec = std::vector<JetConstPair>;
@@ -48,7 +50,7 @@ TLorentzVector exchangeBoson, smearExchangeBoson;
 /// Each entry of std::vector<JetConstPair> is length 2 - first the truth
 /// jet, then the reco jet
 std::vector<std::vector<JetConstPair>> matchedR1Jets, matchedR1SDJets;
-
+TLorentzPairVec matchedParticles;
 fastjet::ClusterSequence *cs, *truthcs;
 
 TTree *jetTree;

--- a/analysisCode/src/include/SmearedEvent.h
+++ b/analysisCode/src/include/SmearedEvent.h
@@ -32,11 +32,8 @@ class SmearedEvent {
   /// Main workhorse function, which is called from event loop
   void processEvent();
   void setVerbosity(int verb) { m_verbosity = verb; }
+  TLorentzVector getExchangeBoson();
 
-  double getSmearedX() {return m_x;}
-  double getSmearedQ2() {return m_q2;}
-  double getSmearedY() {return m_y;}
-  double getSmearedNu() {return m_nu;}
 
   void setScatteredLepton();
   void setSmearedParticles();
@@ -60,7 +57,6 @@ class SmearedEvent {
   std::vector<PseudoJetVec> m_matchedJets;
   
   PseudoJetVec m_particles;
-  double m_x, m_y, m_q2, m_nu;
   int m_verbosity = 0;
 
  

--- a/analysisCode/src/include/SmearedEvent.h
+++ b/analysisCode/src/include/SmearedEvent.h
@@ -17,6 +17,8 @@ using PseudoJetVec = std::vector<fastjet::PseudoJet>;
 using TLorentzVectorVec = std::vector<TLorentzVector>;
 using JetConstPair = std::pair<TLorentzVector, std::vector<TLorentzVector>>;
 using JetConstVec = std::vector<JetConstPair>;
+using TLorentzPair = std::pair<TLorentzVector, TLorentzVector>;
+using TLorentzPairVec = std::vector<TLorentzPair>;
 
 class SmearedEvent {
   
@@ -37,7 +39,8 @@ class SmearedEvent {
 
   void setScatteredLepton();
   void setSmearedParticles();
-  
+  TLorentzPairVec getMatchedParticles();
+
   PseudoJetVec getRecoJets(fastjet::ClusterSequence *cs,
 			   JetDef jetDef);
   PseudoJetVec getRecoSoftDropJets(PseudoJetVec recoJets, 
@@ -47,6 +50,7 @@ class SmearedEvent {
 					       PseudoJetVec recojets);
 
   void useBreitFrame(bool yesorno) { m_breitFrame = yesorno; }
+
  private:
   /// Need truth event for identifying only final state particles
   erhic::EventPythia *m_truthEvent;
@@ -57,6 +61,7 @@ class SmearedEvent {
   std::vector<PseudoJetVec> m_matchedJets;
   
   PseudoJetVec m_particles;
+  PseudoJetVec m_truthParticles;
   int m_verbosity = 0;
 
  


### PR DESCRIPTION
This PR puts a map on the tree of event by event particle correlations that go into the jet building. This will be used for correlating reco and truth particles in jets for smearing studies. 

The PR also fixes the grabbing of reco x, y,and q2 to grab directly from the EICsmear event class. It also puts the smeared exchange boson four vector on the tree for comparison.