### PR TITLE
Breit Frame

### DIFF
--- a/analysisCode/macros/HistoManager.h
+++ b/analysisCode/macros/HistoManager.h
@@ -34,11 +34,19 @@ TH2 *truenconst, *reconconst;
 TH1 *matchconstp, *matchconstpt;
 TH2 *recomatchdr;
 TH1 *nrecojets, *ntruthjets;
+TH2 *truthjetbosonphi, *truthjetbosontheta, *truthjetbosoneta;
+TH2 *truejetpttheta, *truejetptheta;
 
 void write()
 {
   outfile = new TFile("histos.root","RECREATE");
 
+  truthjetbosonphi->Write();
+  truthjetbosontheta->Write();
+  truthjetbosoneta->Write();
+  truejetpttheta->Write();
+  truejetptheta->Write();
+  
   recosubjetpt->Write();
   truthsubjetpt->Write();
   sdenergygroomed->Write();
@@ -99,6 +107,12 @@ void instantiateHistos()
     {
       zgbins[i] = 0 + i * 0.5 / nzgbins;
     }
+  truejetptheta = new TH2F("truejetptheta",";p^{true} [GeV]; #theta_{jet}^{true} [rad]", 50,0,50,300,-4,4);
+  truejetpttheta = new TH2F("truejetpttheta",";p_{T}^{true} [GeV]; #theta_{jet}^{true} [rad]", 50,0,50,300,-4,4);
+  truthjetbosonphi = new TH2F("truthjetbosonphi",";#phi^{truth}_{boson} [rad]; #phi^{truth}_{jet} [rad]",300,-3.14159,3.14159, 300,-3.14159,3.14159);
+  truthjetbosoneta = new TH2F("truthjetbosoneta",";#eta^{truth}_{boson};#eta^{truth}_{jet}",300,-40,40,300,-40,40);
+  truthjetbosontheta = new TH2F("truthjetbosontheta",";#theta^{truth}_{boson} [rad]; #theta^{truth}_{jet} [rad]",300,-4,4,300,-4,4);
+
   recosubjetpt = new TH2F("recosubjetpt",";p_{T}^{subjet,1} [GeV];p_{T}^{subjet,2} [GeV]", 40,0,40,40,0,40);
   truthsubjetpt = new TH2F("truthsubjetpt",";p_{T}^{subjet,1} [GeV];p_{T}^{subjet,2} [GeV]", 40,0,40,40,0,40);
 
@@ -146,9 +160,9 @@ void instantiateHistos()
   trueQ2pT = new TH2F("trueq2pt",";Q_{true}^{2} [GeV^{2}]; p_{T}^{true} [GeV]",
 		      nq2bins,qbins,nptbins,ptbins);
   truejetpteta = new TH2F("truejetpteta",";p_{T}^{true} [GeV]; #eta",
-			  30,4,34,50,-3,3);
+			  34,0,34,500,-30,30);
   truejetptphi = new TH2F("truejetptphi",";p_{T}^{true} [GeV]; #phi [rad]",
-			  30,4,34,50,-3.14159,3.14159);
+			  34,0,34,50,-3.14159,3.14159);
   recojetptz = new TH2F("recojetptz",";z_{reco};p_{T}^{jet,reco} [GeV]",
 			nzbins,zbins,nptbins,ptbins);
   recojetptjt = new TH2F("recojetptjt",
@@ -164,7 +178,7 @@ void instantiateHistos()
   truejetptr = new TH2F("truejetptr",";r_{true}; p_{T}^{jet,true} [GeV]",
 			nrbins,rbins,nptbins,ptbins);
   recojetpteta = new TH2F("recojetpteta", ";p_{T}^{jet,reco} [GeV]; #eta",
-			  30,4,34,50,-3,3);
+			  30,4,34,500,-30,30);
   recojetptphi = new TH2F("recojetptphi",";p_{T}^{jet,reco} [GeV]; #phi",
 			  30,4,34,50,-3.14159,3.14159);
   recotruejetpt = new TH2F("recotruejetpt",";p_{T}^{jet,true} [GeV]; p_{T}^{jet,reco} [GeV]",

--- a/analysisCode/macros/analyzeJets.C
+++ b/analysisCode/macros/analyzeJets.C
@@ -15,19 +15,7 @@ void analyzeJets(std::string file)
   if(filename.find("breit") != string::npos)
     {
       breitFrame = true;
-      // Swap the q binning around, since breit frame specifically boosts
-      // q to be -pz
-      float dummybins[nq2bins+1];
-      for(int i = 0; i < nq2bins+1; i++)
-	{
-	  dummybins[i] = qbins[i];
-	}
-      
-      for(int i = 0; i < nq2bins+1; i++)
-	{
-	  //qbins[i] = dummybins[nq2bins-i] * -1;
-	}
-      
+         
       /// minimum pT and jet eta are going to be affected also
       /// because hard scattered jet is now at theta ~ 0
       /// so we will actually cut on theta instead of eta
@@ -177,8 +165,8 @@ void loop()
       trueQ2x->Fill(truex,trueq2);
   
       trueQ2pT->Fill(trueq2, highestTruthJetPt);
-      //truthExchangeBoson;
-      
+    
+      /// Make some event level histograms of jets+exchange boson
       for(int jet = 0; jet < truthJets->size(); jet++)
 	{
 	  TLorentzVector jetVec;

--- a/analysisCode/macros/analyzeJets.h
+++ b/analysisCode/macros/analyzeJets.h
@@ -16,6 +16,7 @@ using MatchedJets = std::vector<JetConstVec>;
 using TLorentzPair = std::pair<TLorentzVector, TLorentzVector>;
 using TLorentzPairVec = std::vector<TLorentzPair>;
 
+bool breitFrame = false;
 
 void setupTree();
 void instantiateHistos();
@@ -35,13 +36,14 @@ void compareAKTSDTruthJets(JetConstVec *truthjets, JetConstVec *truthsdjets);
 
 float checkdPhi(float dphi);
 
-const float minjetpt = 4;
-const float maxjeteta = 2.5;
-
+/// non-const so that they can be changed if breit frame
+float minjetpt = 3;
+float maxjeteta = 2.5;
+const float maxjettheta = 0.4;
 
 const int nxbins = 41;
 const int nq2bins = 101;
-const int nptbins = 14;
+const int nptbins = 18;
 const int npbins = 42;
 const int nzbins = 55;
 const int njtbins = 44;
@@ -52,7 +54,7 @@ float zgbins[nzgbins+1]; //zgbins set in instantiateHistos()
 
 float pbins[npbins+1] = {2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,22,24,26,28,30,32,34,36,38,40,44,48,52,56,60,70,80,90,100,120,140,160,180,200};
 
-float ptbins[nptbins+1]={4,5,6,7,8,9,10,11,12,14,16,18,20,24,30};
+float ptbins[nptbins+1]={0,1,2,3,4,5,6,7,8,9,10,11,12,14,16,18,20,24,30};
 
 float xbins[nxbins+1] = {0.0001,0.0002,0.0003,0.0004,0.0005,0.0006,0.0007,
 			 0.0008,0.0009,0.001,0.002,0.003,0.004,0.005,0.006,

--- a/analysisCode/macros/sPhenixStyle.C
+++ b/analysisCode/macros/sPhenixStyle.C
@@ -38,7 +38,7 @@ TStyle* sPhenixStyle()
 
   // set margin sizes
   sphenixStyle->SetPadTopMargin(0.05);
-  sphenixStyle->SetPadRightMargin(0.05);
+  sphenixStyle->SetPadRightMargin(0.13);
   sphenixStyle->SetPadBottomMargin(0.16);
   sphenixStyle->SetPadLeftMargin(0.16);
 

--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -34,7 +34,16 @@ int main(int argc, char **argv)
 
   JetDef R1jetdef(fastjet::antikt_algorithm, 1.0);
   R1jetdef.setMinJetPt(2.);
-  R1jetdef.setMaxJetRapidity(4);
+  R1jetdef.setMaxJetRapidity(3.5);
+  
+  /// Breit frame puts hard scattered jet at theta = 0 with minimal pT.
+  /// So we need "loose" jet finding criteria to include everything, and then
+  /// select jets based on cos(theta*) in analysis
+  if(breitFrame)
+    {
+      R1jetdef.setMinJetPt(0.);
+      R1jetdef.setMaxJetRapidity(400);
+    }
   SoftDropJetDef R1sd(0.1, 0, R1jetdef.getR());
 
   std::cout<<"begin event loop"<<std::endl;
@@ -44,7 +53,7 @@ int main(int argc, char **argv)
 	std::cout<<"Processed " << event << " events" << std::endl;
 
       mctree->GetEntry(event);
-
+      processId = truthEvent->GetProcess();
       truex = truthEvent->GetTrueX();
       truey = truthEvent->GetTrueY();
       trueq2 = truthEvent->GetTrueQ2();
@@ -60,6 +69,7 @@ int main(int argc, char **argv)
       trueEvent.setMinY(0.05);
       trueEvent.setMaxY(0.95);
       trueEvent.setMinX(0.00001);
+      trueEvent.setProcessId(99);
       /// Check the cuts
       if(!trueEvent.passCuts()){
 	continue;
@@ -134,7 +144,7 @@ std::vector<std::vector<JetConstPair>> convertMatchedJetVec(std::vector<PseudoJe
 
 void setupJetTree(TTree *tree)
 {
-
+  jetTree->Branch("processId",&processId,"processId/I");
   jetTree->Branch("truthR1Jets", &truthR1Jets);
   jetTree->Branch("recoR1Jets", &recoR1Jets);
   jetTree->Branch("recoR1SDJets", &recoR1SDJets);

--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -34,7 +34,7 @@ int main(int argc, char **argv)
 
   JetDef R1jetdef(fastjet::antikt_algorithm, 1.0);
   R1jetdef.setMinJetPt(2.);
-  R1jetdef.setMaxJetRapidity(3.5);
+  R1jetdef.setMaxJetRapidity(4);
   
   /// Breit frame puts hard scattered jet at theta = 0 with minimal pT.
   /// So we need "loose" jet finding criteria to include everything, and then
@@ -70,6 +70,7 @@ int main(int argc, char **argv)
       trueEvent.setMaxY(0.95);
       trueEvent.setMinX(0.00001);
       trueEvent.setProcessId(99);
+      
       /// Check the cuts
       if(!trueEvent.passCuts()){
 	continue;

--- a/analysisCode/src/TruthEvent.cpp
+++ b/analysisCode/src/TruthEvent.cpp
@@ -34,6 +34,7 @@ bool TruthEvent::passCuts()
   double y = m_truthEvent->GetTrueY();
   double x = m_truthEvent->GetTrueX();
   double q2 = m_truthEvent->GetTrueQ2();
+  int processId = m_truthEvent->GetProcess();
   
   if(m_verbosity > 3)
     {
@@ -41,7 +42,7 @@ bool TruthEvent::passCuts()
 		<< "," << y << std::endl;
     }
   
-  return x > m_minX && y > m_minY && y < m_maxY && q2 > m_minq2;
+  return x > m_minX && y > m_minY && y < m_maxY && q2 > m_minq2 && processId == m_processId;
 }
 void TruthEvent::setScatteredLepton()
 {

--- a/analysisCode/src/include/EventLoop.h
+++ b/analysisCode/src/include/EventLoop.h
@@ -43,6 +43,7 @@ std::vector<std::vector<JetConstPair>> convertMatchedJetVec(std::vector<PseudoJe
 JetConstVec truthR1Jets, recoR1Jets, recoR1SDJets, truthR1SDJets;
 double truex, truey, trueq2, truenu;
 double recx, recy, recq2, recnu;
+int processId;
 TLorentzVector exchangeBoson, smearExchangeBoson;
 
 /// This structure is a vector of vector of matched truth-reco jets. 

--- a/analysisCode/src/include/TruthEvent.h
+++ b/analysisCode/src/include/TruthEvent.h
@@ -42,11 +42,12 @@ class TruthEvent {
   void setMinY(double y) {m_minY = y; }
   void setMaxY(double y) {m_maxY = y; }
   void setMinX(double x) {m_minX = x; }
+  void setProcessId(int id) {m_processId = id;}
   bool passCuts();
   TLorentzVector getExchangeBoson();
 
  private:
-
+  int m_processId;
   double m_minq2;
   double m_minY;
   double m_maxY;


### PR DESCRIPTION
Introduce some breit frame analysis level changes. Since the breit frame boosts the photon-jet along the z axis, we need to introduce alternative analysis level cuts on the jets because they now have very high rapidity and almost no transverse momentum, at least in the leading order diagrams. This PR introduces some changes that allow lab frame and breit frame cuts to work simultaneously. There are some histograms added at analysis level that show the results of the cuts in the breit frame.

