### PR TITLE
Integrated Luminosity

### DIFF
--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
       R1jetdef.setMaxJetRapidity(std::numeric_limits<int>::max());
     }
   SoftDropJetDef R1sd(0.1, 0, R1jetdef.getR());
-
+  
   /// Collect information to write out integrated lumi from PYTHIA run
   TObjString *nEventsString(NULL), *crossSectionString(NULL), 
     *nEventsTriedString(NULL);
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
     stringstream(nEventsTriedString->GetString().Data()) >> nEventsTried;
   }
 
-  integratedLumi = nEventsTried / totalCrossSection;
+  integratedLumi = (float) nEventsGen / totalCrossSection;
   runTree->Fill();
   
   std::cout<<"begin event loop"<<std::endl;
@@ -168,6 +168,7 @@ std::vector<std::vector<JetConstPair>> convertMatchedJetVec(std::vector<PseudoJe
 
 void setupRunTree()
 {
+  runTree = new TTree("runTree","A tree with run info");
   runTree->Branch("nEventsTried", &nEventsTried, "nEventsTried/F");
   runTree->Branch("nEventsGen", &nEventsGen, "nEventsGen/F");
   runTree->Branch("totalCrossSection", &totalCrossSection, "totalCrossSection/F");

--- a/analysisCode/src/include/EventLoop.h
+++ b/analysisCode/src/include/EventLoop.h
@@ -33,7 +33,8 @@ using JetConstPair = std::pair<TLorentzVector, std::vector<TLorentzVector>>;
 using JetConstVec = std::vector<JetConstPair>;
 
 
-void setupJetTree(TTree *tree);
+void setupJetTree();
+void setupRunTree();
 
 JetConstVec convertToTLorentzVectors(PseudoJetVec pseudoJets, bool SDJet);
 std::vector<std::vector<JetConstPair>> convertMatchedJetVec(std::vector<PseudoJetVec> vec, bool SDJet);
@@ -44,6 +45,8 @@ JetConstVec truthR1Jets, recoR1Jets, recoR1SDJets, truthR1SDJets;
 double truex, truey, trueq2, truenu;
 double recx, recy, recq2, recnu;
 int processId;
+float nEventsTried, totalCrossSection, nEventsGen;
+float integratedLumi;
 TLorentzVector exchangeBoson, smearExchangeBoson;
 
 /// This structure is a vector of vector of matched truth-reco jets. 
@@ -53,4 +56,4 @@ std::vector<std::vector<JetConstPair>> matchedR1Jets, matchedR1SDJets;
 TLorentzPairVec matchedParticles;
 fastjet::ClusterSequence *cs, *truthcs;
 
-TTree *jetTree;
+TTree *jetTree, *runTree;

--- a/condorEventGen/run_runSimWorkflow.job
+++ b/condorEventGen/run_runSimWorkflow.job
@@ -10,7 +10,7 @@ basepath        = /sphenix/user/jdosbo/EICSmear/git/jetSubstructure/
 proton          = 275
 electron        = 18
 minq2           = 9
-nevents         = 1000
+nevents         = 1000000
 smear           = smeared_pE$(proton)_pE$(electron)_minqsq$(minq2)_$(Process)
 truth           = truth_pE$(proton)_pE$(electron)_minqsq$(minq2)_$(Process)
 
@@ -23,4 +23,4 @@ Error           = $(Initialdir)/logfiles/job_pE$(proton)_pE$(electron)_minqsq$(m
 Log             = $(Initialdir)/logfiles/job_pE$(proton)_pE$(electron)_minqsq$(minq2)_$(Process).log
 
 
-Queue    10
+Queue    100

--- a/pythiaGeneration/runPythiaeRhic.py
+++ b/pythiaGeneration/runPythiaeRhic.py
@@ -53,15 +53,15 @@ def runPythia(outfile, protonEnergy, electronEnergy, minQ2,
     finalPythiaFile.write(defaultPythia)
     finalPythiaFile.close()
     
-    executable = "$EICDIRECTORY/bin/pythiaeRHIC < " + pythiafilename
+    executable = "$EICDIRECTORY/bin/pythiaeRHIC < " + pythiafilename + " > logfile_" + processID + ".log"
     os.system(executable)
     
     # Convert the ugly text file to a root tree with truth information
     import ROOT
     ROOT.gSystem.Load("libeicsmear")
-    ROOT.BuildTree(outfile, ".", -1)
+    ROOT.BuildTree(outfile, ".", -1,"logfile_"+processID+".log")
     
     # remove the files we created once we are finished with it
     os.system("rm " + pythiafilename)
     os.system("rm " + outfile)
-    
+    os.system("rm logfile_"+processID+".log")


### PR DESCRIPTION
This PR adds a new run info tree that outputs the integrated luminosity for a given run. At the moment, the luminosity is calculated with the total number of events generated. In the future, this should be switched to the total number of events tried once the bug is fixed in eicsmear.