### PR TITLE
Chain trees

### DIFF
--- a/analysisCode/condor/RunEventLoop.csh
+++ b/analysisCode/condor/RunEventLoop.csh
@@ -1,0 +1,20 @@
+#!/bin/csh
+
+setenv HOME /phenix/u/jdosbo
+
+source /etc/csh.login
+foreach i (/etc/profile.d/*.csh)
+    source $i
+end
+
+source $HOME/.cshrc
+
+setenv EIC_LEVEL dev
+
+source /afs/rhic.bnl.gov/eic/restructured/etc/eic_cshrc.csh
+
+# basepath argument
+cd $5
+cd analysisCode
+
+./EventLoop $1 $2 $3 $4

--- a/analysisCode/condor/RunEventLoop.job
+++ b/analysisCode/condor/RunEventLoop.job
@@ -1,0 +1,24 @@
+Universe        = vanilla
+
+Notification    = Never
+Priority        = 1
+
+# Change this path to where ever jetSubstructure lives 
+basepath        = /sphenix/user/jdosbo/EICSmear/git/jetSubstructure/
+
+# Other arguments for script to run
+truthfile       = $(basepath)/MCData/largeJob100MEvents/truth_pE275_pE18_minqsq9_$(Process).root
+smearfile       = $(basepath)/MCData/largeJob100MEvents/smeared_pE275_pE18_minqsq9_$(Process).root
+breit           = 0
+outfile         = pE275_pE18_minqsq9_$(Process)_breit$(breit).root
+
+Arguments       = $(truthfile) $(smearfile) $(outfile) $(breit) $(basepath)
+
+Initialdir      = $(basepath)/analysisCode/condor
+Executable      = $(Initialdir)/RunEventLoop.csh
+Output          = $(Initialdir)/logfiles/job_$(Process).out
+Error           = $(Initialdir)/logfiles/job_$(Process).err
+Log             = $(Initialdir)/logfiles/job_$(Process).log
+
+
+Queue    100

--- a/analysisCode/macros/HistoManager.h
+++ b/analysisCode/macros/HistoManager.h
@@ -37,9 +37,10 @@ TH1 *nrecojets, *ntruthjets;
 TH2 *truthjetbosonphi, *truthjetbosontheta, *truthjetbosoneta;
 TH2 *truejetpttheta, *truejetptheta;
 
-void write()
+void write(std::string filename)
 {
-  outfile = new TFile("histos.root","RECREATE");
+  std::string file = filename + "_histos.root";
+  outfile = new TFile(file.c_str(),"RECREATE");
 
   truthjetbosonphi->Write();
   truthjetbosontheta->Write();

--- a/analysisCode/macros/analyzeJets.C
+++ b/analysisCode/macros/analyzeJets.C
@@ -30,7 +30,7 @@ void analyzeJets(std::string file)
 
   loop();
 
-  write();
+  write(filename);
 }
 
 

--- a/analysisCode/macros/analyzeJets.h
+++ b/analysisCode/macros/analyzeJets.h
@@ -21,7 +21,7 @@ bool breitFrame = false;
 void setupTree();
 void instantiateHistos();
 void loop();
-void write();
+void write(std::string filename);
 
 
 void recoJetAnalysis(JetConstVec *recojets);

--- a/analysisCode/macros/condor/RunAnalyzeJets.csh
+++ b/analysisCode/macros/condor/RunAnalyzeJets.csh
@@ -1,0 +1,20 @@
+#!/bin/csh
+
+setenv HOME /phenix/u/jdosbo
+
+source /etc/csh.login
+foreach i (/etc/profile.d/*.csh)
+    source $i
+end
+
+source $HOME/.cshrc
+
+setenv EIC_LEVEL dev
+
+source /afs/rhic.bnl.gov/eic/restructured/etc/eic_cshrc.csh
+
+# basepath argument
+cd $2
+cd analysisCode/macros
+
+root -l analyzeJets.C\(\"$1\"\)

--- a/analysisCode/macros/condor/RunAnalyzeJets.job
+++ b/analysisCode/macros/condor/RunAnalyzeJets.job
@@ -1,0 +1,21 @@
+Universe        = vanilla
+
+Notification    = Never
+Priority        = 1
+
+# Change this path to where ever jetSubstructure lives 
+basepath        = /sphenix/user/jdosbo/EICSmear/git/jetSubstructure/
+
+# Other arguments for script to run
+breit           = 0
+infile          = data/pE275_pE18_minqsq9_$(Process)_breit$(breit).root
+Arguments       = $(infile) $(basepath)
+
+Initialdir      = $(basepath)/analysisCode/macros/condor
+Executable      = $(Initialdir)/RunAnalyzeJets.csh
+Output          = $(Initialdir)/logfiles/job_$(Process).out
+Error           = $(Initialdir)/logfiles/job_$(Process).err
+Log             = $(Initialdir)/logfiles/job_$(Process).log
+
+
+Queue    100


### PR DESCRIPTION
This PR commits some condor scripts and changes to the analysis macros so that each step of the analysis chain can be run on condor. This allows for quick data processing of each step, since there are now (e.g.) 100 files with 1M events each. So rather than processing 1 job of 100M events, these scripts now allow you to process 100 jobs for each step of the analysis chain. The final resulting histograms could be added together via the ROOT `hadd` [functionality](https://root.cern.ch/how/how-merge-histogram-files).