### PR TITLE
Draw Histo macro, few fixes

### DIFF
--- a/analysisCode/condor/RunEventLoop.job
+++ b/analysisCode/condor/RunEventLoop.job
@@ -16,9 +16,9 @@ Arguments       = $(truthfile) $(smearfile) $(outfile) $(breit) $(basepath)
 
 Initialdir      = $(basepath)/analysisCode/condor
 Executable      = $(Initialdir)/RunEventLoop.csh
-Output          = $(Initialdir)/logfiles/job_$(Process).out
-Error           = $(Initialdir)/logfiles/job_$(Process).err
-Log             = $(Initialdir)/logfiles/job_$(Process).log
+Output          = $(Initialdir)/logfiles/job_$(Process)_$(breit).out
+Error           = $(Initialdir)/logfiles/job_$(Process)_$(breit).err
+Log             = $(Initialdir)/logfiles/job_$(Process)_$(breit).log
 
 
 Queue    100

--- a/analysisCode/macros/AnalyzeHistos.C
+++ b/analysisCode/macros/AnalyzeHistos.C
@@ -20,17 +20,24 @@ void AnalyzeHistos()
 {
   SetsPhenixStyle();
   TFile *file = TFile::Open("lab.root");
-  TFile *bfile = TFile::Open("breithistos.root");
+  TFile *bfile = TFile::Open("breit.root");
   
   TH2 *truejetptz = (TH2F*)file->Get("truejetptz");
   TH2 *truejetptr = (TH2F*)file->Get("truejetptr");
   TH2 *truejetptjt = (TH2F*)file->Get("truejetptjt");
   TH2 *truenconst = (TH2F*)file->Get("truenconst");
+  TH2 *trueSDrg = (TH2F*)file->Get("truthSDjetrg");
+  TH2 *trueSDzg = (TH2F*)file->Get("truthSDjetzg");
   
+  TH2 *btrueSDrg = (TH2F*)bfile->Get("truthSDjetrg");
+  TH2 *btrueSDzg = (TH2F*)bfile->Get("truthSDjetzg");
   TH2 *btruejetptz = (TH2F*)bfile->Get("truejetptz");
   TH2 *btruejetptr = (TH2F*)bfile->Get("truejetptr");
   TH2 *btruejetptjt = (TH2F*)bfile->Get("truejetptjt");
   TH2 *btruenconst = (TH2F*)bfile->Get("truenconst");
+
+  btrueSDrg->SetName("btruthSDjetrg");
+  btrueSDzg->SetName("btruthSDjetzg");
   btruenconst->SetName("btruenconst");
   btruejetptz->SetName("btruejetptz");
   btruejetptr->SetName("btruejetptr");
@@ -49,6 +56,38 @@ void AnalyzeHistos()
   drawFitProfile(truenconst, truenconstfit);
   drawFitProfile(btruenconst, btruenconstfit);
 
+  TH1D *zgproj = trueSDzg->ProjectionX("zgproj",10,11);
+  TH1D *bzgproj = btrueSDzg->ProjectionX("bzgproj",10,11);
+  TH1D *rgproj = trueSDrg->ProjectionX("rgproj",10,11);
+  TH1D *brgproj = btrueSDrg->ProjectionX("brgproj",10,11);
+
+  TCanvas *zgbreitlabcan = new TCanvas("zgbreitlabcan","zgbreitlabcan",
+				       200,200,1000,800);
+  zgproj->Scale(1./zgproj->GetEntries());
+  bzgproj->Scale(1./bzgproj->GetEntries());
+  bzgproj->GetXaxis()->SetTitle("z_{g}^{true}");
+  bzgproj->GetYaxis()->SetTitle("Normalized Counts");
+  bzgproj->SetLineColor(kRed);
+  bzgproj->SetMarkerColor(kRed);
+  bzgproj->Draw("hist");
+  zgproj->Draw("histsame");
+  TLegend *leggg = new TLegend(0.7,0.6,0.8,0.8);
+  leggg->AddEntry(zgproj,"Lab","L");
+  leggg->AddEntry(bzgproj,"Breit","L");
+  leggg->AddEntry((TObject*)0,"9<p_{T}^{jet}<10 GeV","");
+  leggg->Draw("same");
+  
+  TCanvas *rgbreitlabcan = new TCanvas("rgbreitlabcan","rgbreitlabcan",
+				       200,200,1000,800);
+  rgproj->Scale(1./rgproj->GetEntries());
+  brgproj->Scale(1./brgproj->GetEntries());
+  brgproj->GetXaxis()->SetTitle("R_{g}^{true}");
+  brgproj->GetYaxis()->SetTitle("Normalized Counts");
+  brgproj->SetLineColor(kRed);
+  brgproj->SetMarkerColor(kRed);
+  brgproj->Draw("hist");
+  rgproj->Draw("histsame");
+  leggg->Draw("same");
 
 
   TCanvas *zbreitlabcan = new TCanvas("zbreitlabcan","zbreitlabcan",

--- a/analysisCode/macros/HistoManager.h
+++ b/analysisCode/macros/HistoManager.h
@@ -112,8 +112,8 @@ void instantiateHistos()
       zgbins[i] = 0 + i * 0.5 / nzgbins;
     }
 
-  h_xsec = new TH1F("h_xsec",";#sigma [nb]",1000,0,0.0001);
-  h_lumi = new TH1F("h_lumi",";Luminosity [nb]^{-1}",1000,10e9,10e11);
+  h_xsec = new TH1F("h_xsec",";#sigma [#mub]",1000,0,0.0001);
+  h_lumi = new TH1F("h_lumi",";Luminosity [#mub]^{-1}",1000,10e9,10e11);
   h_eventsGen = new TH1F("h_eventsGen",";N_{events}",10000000,0,10000000);
   truejetptheta = new TH2F("truejetptheta",";p^{true} [GeV]; #theta_{jet}^{true} [rad]", 50,0,50,300,-4,4);
   truejetpttheta = new TH2F("truejetpttheta",";p_{T}^{true} [GeV]; #theta_{jet}^{true} [rad]", 50,0,50,300,-4,4);

--- a/analysisCode/macros/HistoManager.h
+++ b/analysisCode/macros/HistoManager.h
@@ -36,12 +36,15 @@ TH2 *recomatchdr;
 TH1 *nrecojets, *ntruthjets;
 TH2 *truthjetbosonphi, *truthjetbosontheta, *truthjetbosoneta;
 TH2 *truejetpttheta, *truejetptheta;
+TH1 *h_lumi, *h_eventsGen, *h_xsec;
 
 void write(std::string filename)
 {
   std::string file = filename + "_histos.root";
   outfile = new TFile(file.c_str(),"RECREATE");
-
+  h_lumi->Write();
+  h_xsec->Write();
+  h_eventsGen->Write();
   truthjetbosonphi->Write();
   truthjetbosontheta->Write();
   truthjetbosoneta->Write();
@@ -108,6 +111,10 @@ void instantiateHistos()
     {
       zgbins[i] = 0 + i * 0.5 / nzgbins;
     }
+
+  h_xsec = new TH1F("h_xsec",";#sigma [nb]",1000,0,0.0001);
+  h_lumi = new TH1F("h_lumi",";Luminosity [nb]^{-1}",1000,10e9,10e11);
+  h_eventsGen = new TH1F("h_eventsGen",";N_{events}",10000000,0,10000000);
   truejetptheta = new TH2F("truejetptheta",";p^{true} [GeV]; #theta_{jet}^{true} [rad]", 50,0,50,300,-4,4);
   truejetpttheta = new TH2F("truejetpttheta",";p_{T}^{true} [GeV]; #theta_{jet}^{true} [rad]", 50,0,50,300,-4,4);
   truthjetbosonphi = new TH2F("truthjetbosonphi",";#phi^{truth}_{boson} [rad]; #phi^{truth}_{jet} [rad]",300,-3.14159,3.14159, 300,-3.14159,3.14159);

--- a/analysisCode/macros/analyzeJets.C
+++ b/analysisCode/macros/analyzeJets.C
@@ -198,10 +198,6 @@ void analyzeMatchedJets(MatchedJets *matchedjets,
 
       if(truthJet.Pt() < minjetpt || fabs(truthJet.Eta()) > maxjeteta)
 	continue;
-      
-      if(breitFrame)
-	if(truthJet.Theta() > maxjeteta)
-	  continue;
 
       if(recoJet.Pt() > minjetpt && fabs(recoJet.Eta()) < maxjeteta)
 	{

--- a/analysisCode/macros/analyzeJets.C
+++ b/analysisCode/macros/analyzeJets.C
@@ -24,10 +24,32 @@ void analyzeJets(std::string file)
 
   loop();
 
+  getLumi();
+
   write(filename);
+
 }
 
+void getLumi()
+{
 
+  TTree *runtree = (TTree*)infile->Get("runTree");
+  float lumi;
+  float xsec;
+  float events;
+  runtree->SetBranchAddress("totalCrossSection",&xsec);
+  runtree->SetBranchAddress("nEventsGen",&events);
+  runtree->SetBranchAddress("integratedLumi",&lumi);
+  for(int i = 0; i< runtree->GetEntries(); i++)
+    {
+      runtree->GetEntry(i);
+      h_lumi->Fill(lumi);
+      h_eventsGen->Fill(events);
+      h_xsec->Fill(xsec);
+      std::cout<<xsec<<"  "<<lumi<<"  "<<events<<std::endl;
+    }
+
+}
 void recoJetAnalysis(JetConstVec *recojets)
 {
   int njets = 0;
@@ -208,6 +230,7 @@ void analyzeMatchedJets(MatchedJets *matchedjets,
       
       if(truthJet.DeltaR(recoJet) > 0.5)
 	continue;
+   
 
       truereconconst->Fill(truthConst.size(), recoConst.size());
 
@@ -404,6 +427,8 @@ void analyzeMatchedSDJets(MatchedJets *matchedjets)
 
 
 }
+
+
 
 void setupTree()
 {

--- a/analysisCode/macros/analyzeJets.C
+++ b/analysisCode/macros/analyzeJets.C
@@ -22,19 +22,25 @@ void analyzeJets(std::string file)
 
   instantiateHistos();
 
-  loop();
-
+  std::cout<<"Get int lumi"<<std::endl;
   getLumi();
 
+
+  std::cout<<"looping over events"<<std::endl;
+  loop();
+
+
+  std::cout<<"Write to outfile"<<std::endl;
   write(filename);
 
+  std::cout<<"Finished"<<std::endl;
 }
 
 void getLumi()
 {
 
   TTree *runtree = (TTree*)infile->Get("runTree");
-  float lumi;
+ 
   float xsec;
   float events;
   runtree->SetBranchAddress("totalCrossSection",&xsec);
@@ -46,10 +52,13 @@ void getLumi()
       h_lumi->Fill(lumi);
       h_eventsGen->Fill(events);
       h_xsec->Fill(xsec);
-      std::cout<<xsec<<"  "<<lumi<<"  "<<events<<std::endl;
+      
     }
 
 }
+
+
+
 void recoJetAnalysis(JetConstVec *recojets)
 {
   int njets = 0;

--- a/analysisCode/macros/analyzeJets.h
+++ b/analysisCode/macros/analyzeJets.h
@@ -36,6 +36,8 @@ void compareAKTSDTruthJets(JetConstVec *truthjets, JetConstVec *truthsdjets);
 
 float checkdPhi(float dphi);
 
+float lumi;
+
 const float minjetpt = 3;
 const float maxjeteta = 2.5;
 

--- a/analysisCode/macros/analyzeJets.h
+++ b/analysisCode/macros/analyzeJets.h
@@ -22,7 +22,7 @@ void setupTree();
 void instantiateHistos();
 void loop();
 void write(std::string filename);
-
+void getLumi();
 
 void recoJetAnalysis(JetConstVec *recojets);
 /// Returns highest truth jet pt in event

--- a/analysisCode/macros/condor/RunAnalyzeJets.job
+++ b/analysisCode/macros/condor/RunAnalyzeJets.job
@@ -8,14 +8,14 @@ basepath        = /sphenix/user/jdosbo/EICSmear/git/jetSubstructure/
 
 # Other arguments for script to run
 breit           = 0
-infile          = data/pE275_pE18_minqsq9_$(Process)_breit$(breit).root
+infile          = data/lab/pE275_pE18_minqsq9_$(Process)_breit$(breit).root
 Arguments       = $(infile) $(basepath)
 
 Initialdir      = $(basepath)/analysisCode/macros/condor
 Executable      = $(Initialdir)/RunAnalyzeJets.csh
-Output          = $(Initialdir)/logfiles/job_$(Process).out
-Error           = $(Initialdir)/logfiles/job_$(Process).err
-Log             = $(Initialdir)/logfiles/job_$(Process).log
+Output          = $(Initialdir)/logfiles/job_$(Process)_$(breit).out
+Error           = $(Initialdir)/logfiles/job_$(Process)_$(breit).err
+Log             = $(Initialdir)/logfiles/job_$(Process)_$(breit).log
 
 
 Queue    100

--- a/analysisCode/macros/data/AnalyzeHistos.C
+++ b/analysisCode/macros/data/AnalyzeHistos.C
@@ -1,0 +1,188 @@
+
+
+/**
+ * Quick and ugly macro to draw some histograms and comparisons between
+ * breit frame and lab frame
+ */
+
+#include <TH2.h>
+#include <TFile.h>
+#include <TGraphErrors.h>
+#include "../sPhenixStyle.h"
+#include "../sPhenixStyle.C"
+
+TGraphErrors *FitProfile(const TH2 *h2);
+void drawFitProfile(TH2 *hist, TGraphErrors *gr);
+void draw2DHisto(TH2 *hist);
+void projectBin(TH2 *hist);
+
+void AnalyzeHistos()
+{
+  SetsPhenixStyle();
+  TFile *file = TFile::Open("lab.root");
+  TFile *bfile = TFile::Open("breithistos.root");
+  
+  TH2 *truejetptz = (TH2F*)file->Get("truejetptz");
+  TH2 *truejetptr = (TH2F*)file->Get("truejetptr");
+  TH2 *truejetptjt = (TH2F*)file->Get("truejetptjt");
+  TH2 *truenconst = (TH2F*)file->Get("truenconst");
+  
+  TH2 *btruejetptz = (TH2F*)bfile->Get("truejetptz");
+  TH2 *btruejetptr = (TH2F*)bfile->Get("truejetptr");
+  TH2 *btruejetptjt = (TH2F*)bfile->Get("truejetptjt");
+  TH2 *btruenconst = (TH2F*)bfile->Get("truenconst");
+  btruenconst->SetName("btruenconst");
+  btruejetptz->SetName("btruejetptz");
+  btruejetptr->SetName("btruejetptr");
+  btruejetptjt->SetName("btruejetptjt");
+
+  TGraphErrors *truenconstfit = FitProfile(truenconst);
+  TGraphErrors *btruenconstfit = FitProfile(btruenconst);
+  
+  draw2DHisto(truejetptz);
+  draw2DHisto(truejetptjt);
+  draw2DHisto(truejetptr);
+  draw2DHisto(btruejetptz);
+  draw2DHisto(btruejetptjt);
+  draw2DHisto(btruejetptr);
+  
+  drawFitProfile(truenconst, truenconstfit);
+  drawFitProfile(btruenconst, btruenconstfit);
+
+
+
+  TCanvas *zbreitlabcan = new TCanvas("zbreitlabcan","zbreitlabcan",
+				      200,200,1000,800);
+  TH1D *projection = truejetptz->ProjectionX("zproj",15,16);
+  TH1D *bprojection = btruejetptz->ProjectionX("bzproj",15,16);
+  
+  projection->Scale(1./projection->GetEntries());
+  bprojection->Scale(1./bprojection->GetEntries());
+  gPad->SetLogx();
+  gPad->SetLogy();
+  bprojection->GetXaxis()->SetTitle("z");
+  bprojection->GetYaxis()->SetTitle("Normalized Counts");
+  bprojection->GetXaxis()->SetRangeUser(0.05,1);
+  bprojection->SetLineColor(kRed);
+  bprojection->Draw("hist");
+  projection->Draw("histsame");
+  TLegend *legg = new TLegend(0.2,0.2,0.4,0.4);
+  legg->AddEntry(projection,"Lab","l");
+  legg->AddEntry(bprojection,"Breit","L");
+  legg->AddEntry((TObject*)0,"9<p_{T}^{jet,true}<10 GeV","");
+  legg->Draw("same");
+
+  TCanvas *nconstcan = new TCanvas("nconstcan","nconstcan",
+				   200,200,1000,800);
+
+
+  truenconstfit->GetXaxis()->SetTitle("p_{T}^{jet, true} [GeV]");
+  truenconst->GetYaxis()->SetTitle("N_{const}^{true}");
+  truenconstfit->Draw("aep");
+  btruenconstfit->SetMarkerColor(kRed);
+  btruenconstfit->SetLineColor(kRed);
+  btruenconstfit->Draw("epsame");
+  TLegend *leg = new TLegend(0.2,0.7,0.3,0.8);
+  leg->AddEntry(truenconstfit,"Lab","P");
+  leg->AddEntry(btruenconstfit,"Breit","P");
+  leg->Draw("same");
+
+}
+
+void projectBin(TH2 *hist)
+{
+  ostringstream name;
+  name.str("");
+  name<<"projection_"<<hist->GetName();
+  TH1D *projection = hist->ProjectionX(name.str().c_str(),10,11);
+  
+  TCanvas *can = new TCanvas(name.str().c_str(),name.str().c_str(),
+			     200,200,1000,800);
+  projection->Scale(1./projection->GetEntries());
+  projection->Draw("hist");
+
+
+}
+void draw2DHisto(TH2 *hist)
+{
+  /// normalize the histo by its bin width
+  hist->Scale(1, "width");
+  ostringstream name;
+  name.str("");
+  name<<hist->GetName()<<"_can";
+  TCanvas *can = new TCanvas(name.str().c_str(),name.str().c_str(),
+			     200,200,1000,800);
+
+  gPad->SetLogz();
+  hist->Draw("colz");
+
+}
+
+void drawFitProfile(TH2 *hist, TGraphErrors *gr)
+{
+
+  ostringstream name;
+  name.str("");
+  name<<hist->GetName()<<"_can";
+  TCanvas *can = new TCanvas(name.str().c_str(),name.str().c_str(),
+			     200,200,1000,800);
+  gPad->SetLogz();
+  hist->Draw("colz");
+  gr->Draw("epsame");
+
+
+}
+
+TGraphErrors *FitProfile(const TH2 * h2)
+{
+
+  TProfile * p2 = h2->ProfileX();
+
+  int n = 0;
+  double x[1000];
+  double ex[1000];
+  double y[1000];
+  double ey[1000];
+
+  for (int i = 1; i <= h2->GetNbinsX(); i++)
+    {
+      TH1D * h1 = h2->ProjectionY(Form("htmp_%d", rand()), i, i);
+
+      if (h1->GetSum() < 30)
+        {
+          cout << "FitProfile - ignore bin " << i << endl;
+          continue;
+        }
+     
+
+      TF1 fgaus("fgaus", "gaus", -p2->GetBinError(i) * 4,
+          p2->GetBinError(i) * 4);
+
+      TF1 f2(Form("dgaus"), "gaus + [3]*exp(-0.5*((x-[1])/[4])**2) + [5]",
+          -p2->GetBinError(i) * 4, p2->GetBinError(i) * 4);
+
+      fgaus.SetParameter(1, p2->GetBinContent(i));
+      fgaus.SetParameter(2, p2->GetBinError(i));
+
+      h1->Fit(&fgaus, "MQ");
+
+      f2.SetParameters(fgaus.GetParameter(0) / 2, fgaus.GetParameter(1),
+          fgaus.GetParameter(2), fgaus.GetParameter(0) / 2,
+          fgaus.GetParameter(2) / 4, 0);
+
+      h1->Fit(&f2, "MQ");
+
+
+
+      x[n] = p2->GetBinCenter(i);
+      ex[n] = (p2->GetBinCenter(2) - p2->GetBinCenter(1)) / 2;
+      y[n] = fgaus.GetParameter(1);
+      ey[n] = fgaus.GetParError(1);
+
+      n++;
+      delete h1;
+    }
+
+  return new TGraphErrors(n, x, y, ex, ey);
+}
+

--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -57,8 +57,7 @@ int main(int argc, char **argv)
     stringstream(nEventsTriedString->GetString().Data()) >> nEventsTried;
   }
 
-  /// total cross section is units of micro barn. Convert to nanobarn
-  totalCrossSection /= 1000;
+  /// total cross section is units of micro barn
   integratedLumi = (float) nEventsGen / totalCrossSection;
   runTree->Fill();
   

--- a/analysisCode/src/SmearedEvent.cpp
+++ b/analysisCode/src/SmearedEvent.cpp
@@ -152,10 +152,16 @@ void SmearedEvent::setSmearedParticles()
 
       TLorentzVector *partFourVec = new TLorentzVector();
       partFourVec->SetPxPyPzE(px,py,pz,e);
-
-      if(m_breitFrame)
+      TLorentzVector *truthPartFourVec = new TLorentzVector();
+      truthPartFourVec->SetPxPyPzE(truthParticle->GetPx(),
+				   truthParticle->GetPy(),
+				   truthParticle->GetPz(),
+				   truthParticle->GetE());
+      if(m_breitFrame){
+	breit.labToBreitTruth( truthPartFourVec );
 	breit.labToBreitSmear( partFourVec );
 
+      }
       if(m_verbosity > 0)
 	{
 	  std::cout << "Smeared : " <<partFourVec->Px() << " " 
@@ -168,10 +174,10 @@ void SmearedEvent::setSmearedParticles()
 					       partFourVec->Pz(),
 					       partFourVec->E()));
       /// vectors will have a one-to-one correspondance
-      m_truthParticles.push_back(fastjet::PseudoJet(truthParticle->GetPx(),
-						    truthParticle->GetPy(),
-						    truthParticle->GetPz(),
-						    truthParticle->GetE()));
+      m_truthParticles.push_back(fastjet::PseudoJet(truthPartFourVec->Px(),
+						    truthPartFourVec->Py(),
+						    truthPartFourVec->Pz(),
+						    truthPartFourVec->E()));
     }
 
   return;


### PR DESCRIPTION
This PR adds a crude macro that draws some histograms that may be of interest.

It also fixes a bug that the truth particle was not boosted into the breit frame within `SmearedEvent`. This only affects the reco-truth particle matching for e.g. the z or jT response matrices.

This PR also adds some integrated luminosity steps for determining the luminosity of the MC sample.