### PR TITLE
Smear hcal energy

### DIFF
--- a/analysisCode/macros/HistoManager.h
+++ b/analysisCode/macros/HistoManager.h
@@ -42,13 +42,14 @@ TH2 *h_scatJet;
 TH1 *h_lumi, *h_eventsGen, *h_xsec;
 TH1 *jes[npbins];
 TH1 *h_processID;
+TH2 *h_constpT;
 
 void write(std::string filename)
 {
   std::string file = filename + "_histos.root";
 
   outfile = new TFile(file.c_str(),"RECREATE");
-
+  h_constpT->Write();
   h_processID->Write();
   h_scatJet->Write();
   h_scatLept->Write();
@@ -133,6 +134,7 @@ void instantiateHistos()
 		        200,0,2);
     }
 
+  h_constpT = new TH2F("h_constpT",";p [GeV]; #eta",200,-100,100,100,-3.5,3.5);
   h_processID = new TH1I("h_processID",";Process ID",1000,0,1000);
   h_scatJet = new TH2F("h_scatJet","",36,0.,TMath::Pi(), 200.,0.,200.);
   

--- a/analysisCode/macros/analyzeJets.C
+++ b/analysisCode/macros/analyzeJets.C
@@ -50,8 +50,11 @@ void getLumi()
     {
       runtree->GetEntry(i);
       h_lumi->Fill(lumi);
+      std::cout << "lumi is " << lumi << std::endl;
       h_eventsGen->Fill(events);
+      std::cout<<"events " << events<<std::endl;
       h_xsec->Fill(xsec);
+      std::cout << "xsec is " << xsec << std::endl;
       
     }
 
@@ -103,6 +106,7 @@ void recoJetAnalysis(JetConstVec *recojets)
 	    {
 	      if(con.Pt() > minconstpt)
 		{
+		  h_constpT->Fill(con.P(), con.Eta());
 		  recojetptz->Fill(z, jetpt);
 		  recojetptjt->Fill(jt, jetpt);
 		  recojetptr->Fill(r, jetpt);
@@ -191,7 +195,8 @@ void loop()
       truerecx->Fill(truex,recx);
       truerecy->Fill(truey,recy);
       truerecq2->Fill(trueq2,recq2);
-      trueQ2x->Fill(truex,trueq2);
+      if(highestTruthJetPt>5.)
+	trueQ2x->Fill(truex,trueq2);
       trueQ2pT->Fill(trueq2, highestTruthJetPt);
       if(highestTruthJetPt > 5)
 	h_processID->Fill(processId);
@@ -307,9 +312,9 @@ void analyzeMatchedJets(MatchedJets *matchedjets,
 	  for(int k = 0; k < truthConst.size(); k++)
 	    {
 	      TLorentzVector truthCon = truthConst.at(k);
-	      if(truthCon.Px() == truthMatch.Px() &&
-		 truthCon.Py() == truthMatch.Py() &&
-		 truthCon.Pz() == truthMatch.Pz())
+	      if(fabs(truthCon.Px() - truthMatch.Px()) < 0.0001 &&
+		 fabs(truthCon.Py() - truthMatch.Py()) < 0.0001 &&
+		 fabs(truthCon.Pz() - truthMatch.Pz()) < 0.0001)
 		{
 		  matched = true;
 		  break;

--- a/analysisCode/src/EventLoop.cpp
+++ b/analysisCode/src/EventLoop.cpp
@@ -119,6 +119,10 @@ int main(int argc, char **argv)
       SmearedEvent smearedEvent(*truthEvent, *smearEvent);
       smearedEvent.setVerbosity(0);     
       smearedEvent.useBreitFrame(breitFrame);
+      /// We can smear out the energy of tracks that are not matched to a calo cluster to 
+      /// get a better representation of a particle flow algorithm
+      /// hcal resolution is set in smearedEvent constructor to 10% + 50%/E
+      smearedEvent.smearHCal(false);
       smearedEvent.setMaxPartEta(3.5);
       smearedEvent.setMinPartPt(0.25);
       /// Set smeared particle vectors, apply cuts to particles

--- a/analysisCode/src/include/SmearedEvent.h
+++ b/analysisCode/src/include/SmearedEvent.h
@@ -8,6 +8,7 @@
 #include <eicsmear/erhic/EventPythia.h>
 
 #include <TLorentzVector.h>
+#include <TF1.h>
 
 #include "JetDef.h"
 #include "SoftDropJetDef.h"
@@ -32,7 +33,10 @@ class SmearedEvent {
   SmearedEvent(erhic::EventPythia &truthEvent, Smear::Event &smearEvent)
    : m_truthEvent(&truthEvent)
    , m_smearEvent(&smearEvent)
-  {}
+   , m_smearHCal(false)
+  {
+    m_HCalRes = new TF1("hcalres","sqrt(0.1*0.1+0.5*0.5/x)",0.1,275);
+  }
 
   ~SmearedEvent(){}
 
@@ -61,8 +65,8 @@ class SmearedEvent {
   std::vector<PseudoJetVec> matchTruthRecoJets(PseudoJetVec truthjets, 
 					       PseudoJetVec recojets);
 
-  void useBreitFrame(bool yesorno) { m_breitFrame = yesorno; }
-
+  void useBreitFrame(bool breit) { m_breitFrame = breit; }
+  void smearHCal(bool smear) { m_smearHCal = smear;}
  private:
   /// Need truth event for identifying only final state particles
   erhic::EventPythia *m_truthEvent;
@@ -74,6 +78,9 @@ class SmearedEvent {
   const Smear::ParticleMCS *m_scatLepton;
   bool m_breitFrame;
   std::vector<PseudoJetVec> m_matchedJets;
+
+  TF1 *m_HCalRes;
+  bool m_smearHCal;
 
   /// Vectors of particles to be kept
   PseudoJetVec m_particles;


### PR DESCRIPTION
This PR adds an option to smear out the measured particles energy in the case where the tracks momentum is measured but the energy is not. This is analogous to a track being measured in the HCal in e.g. a particle flow algorithm. The feature is set off by default so that the previous functionality is used by default, where the particle is just assumed to have the pion mass and the energy is calculated that way.